### PR TITLE
add file: template file of .env

### DIFF
--- a/.env-origin
+++ b/.env-origin
@@ -1,0 +1,3 @@
+MONGODB_URI=
+
+# MONGODB_URI=mongodb://localhost:27017


### PR DESCRIPTION
RustからMongoDBにアクセスするために.envにMongoの作動URLの指定が必須とのことで，とりあえず.envのOriginファイルだけ作っときます．
使用時は，このOriginをコピーして.envファイルを作成すればOKに．